### PR TITLE
Add Hetzner Backup control to Server Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# n8n-nodes-hetznercloud
+# n8n-nodes-hcloud
 
 ![n8n.io - Workflow Automation](https://raw.githubusercontent.com/n8n-io/n8n/master/assets/n8n-logo.png)
 
-This repository is the basis for the creation of the Hetzner Cloud API n8n community node available at https://www.npmjs.com/package/n8n-nodes-hetznercloud. This community node always contains the latest updates and fixes. Every change will also be merged into the main product n8n, but sometimes it takes time before the pull requests are accepted.
+This is a fork of https://www.npmjs.com/package/n8n-nodes-hetznercloud, as the developer seems to have abandoned the project.
+I wanted to also be able to enable backup for Hetzner Cloud machines, therefore forked it - and here it is. :-)
+The Node is available at https://www.npmjs.com/package/n8n-nodes-hcloud
+
+Additional features:
+- Enable / Disable server backup
+- Change server protection setting
 
 ## About this node
 
@@ -17,7 +23,7 @@ Currently, n8n is not shipped with this Hetzner Cloud API node. Therefore an ins
 1. Open your n8n server.
 1. Go to **Settings > Community Nodes**.
 1. Select **Install**.
-1. Enter `n8n-nodes-hetznercloud` in **Enter npm package name**.
+1. Enter `n8n-nodes-hcloud` in **Enter npm package name**.
 1. Agree to the [risks](https://docs.n8n.io/integrations/community-nodes/risks/) of using community nodes: select **I understand the risks of installing unverified code from a public source**.
 1. Select **Install**.
 
@@ -47,7 +53,7 @@ npm link
 
 ```
 cd ~/.n8n/nodes
-npm link n8n-nodes-hetznercloud
+npm link n8n-nodes-hcloud
 ```
 
 5. Start the local development area. You need two consoles:

--- a/credentials/HetznerCloudApi.credentials.ts
+++ b/credentials/HetznerCloudApi.credentials.ts
@@ -6,7 +6,7 @@ import type {
 } from 'n8n-workflow';
 
 export class HetznerCloudApi implements ICredentialType {
-	name = 'hetznercloud';
+	name = 'hcloud';
 	displayName = 'Hetzner Cloud API';
 	documentationUrl = 'https://seatable.io/docs/n8n-integration/...';
 	properties: INodeProperties[] = [

--- a/nodes/HetznerCloud/HetznerCloud.node.json
+++ b/nodes/HetznerCloud/HetznerCloud.node.json
@@ -1,17 +1,17 @@
 {
-	"node": "n8n-nodes-base.hetznercloud",
+	"node": "n8n-nodes-base.hcloud",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Data & Storage"],
 	"resources": {
 		"credentialDocumentation": [
 			{
-				"url": "https://docs.n8n.io/credentials/hetznercloud"
+				"url": "https://github.com/OXERY/n8n-nodes-hcloud"
 			}
 		],
 		"primaryDocumentation": [
 			{
-				"url": "https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.hetznercloud/"
+				"url": "https://github.com/OXERY/n8n-nodes-hcloud"
 			}
 		]
 	}

--- a/nodes/HetznerCloud/HetznerCloud.node.ts
+++ b/nodes/HetznerCloud/HetznerCloud.node.ts
@@ -6,8 +6,8 @@ import { HetznerCloudV1 } from './v1/HetznerCloudV1.node';
 export class HetznerCloud extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
-			displayName: 'HetznerCloud',
-			name: 'hetznercloud',
+			displayName: 'Hetzner hcloud',
+			name: 'hcloud',
 			icon: 'file:hetznercloud.svg',
 			group: ['output'],
 			subtitle: '={{$parameter["resource"] + ": " + $parameter["operation"]}}',

--- a/nodes/HetznerCloud/v1/actions/Interfaces.ts
+++ b/nodes/HetznerCloud/v1/actions/Interfaces.ts
@@ -18,7 +18,10 @@ type HetznerCloudMap = {
 		| 'soft_reboot'
 		| 'shutdown'
 		| 'reset'
-		| 'change_server_type';
+		| 'change_server_type'
+		| 'enable_backup'
+		| 'disable_backup'
+		| 'change_protection';
 };
 
 export type HetznerCloud = AllEntities<HetznerCloudMap>;

--- a/nodes/HetznerCloud/v1/actions/certificate/create/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/certificate/create/execute.ts
@@ -27,7 +27,7 @@ export async function create(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/certificate/get/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/certificate/get/execute.ts
@@ -13,7 +13,7 @@ export async function get(this: IExecuteFunctions, index: number): Promise<INode
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/certificate/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/certificate/list/execute.ts
@@ -13,7 +13,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/firewall/create/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/firewall/create/execute.ts
@@ -50,7 +50,7 @@ export async function create(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/firewall/get/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/firewall/get/execute.ts
@@ -11,7 +11,7 @@ export async function get(this: IExecuteFunctions, index: number): Promise<INode
 	};
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/firewall/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/firewall/list/execute.ts
@@ -13,7 +13,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/firewall/remove/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/firewall/remove/execute.ts
@@ -15,7 +15,7 @@ export async function remove(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/firewall/update/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/firewall/update/execute.ts
@@ -19,7 +19,7 @@ export async function update(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/floating_ip/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/floating_ip/list/execute.ts
@@ -13,7 +13,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/image/get/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/image/get/execute.ts
@@ -12,7 +12,7 @@ export async function get(this: IExecuteFunctions, index: number): Promise<INode
 	};
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/image/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/image/list/execute.ts
@@ -15,7 +15,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/image/remove/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/image/remove/execute.ts
@@ -15,7 +15,7 @@ export async function remove(
 	};
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/loadbalancer/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/loadbalancer/list/execute.ts
@@ -13,7 +13,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/network/create/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/network/create/execute.ts
@@ -32,7 +32,7 @@ export async function create(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/network/get/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/network/get/execute.ts
@@ -12,7 +12,7 @@ export async function get(this: IExecuteFunctions, index: number): Promise<INode
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/network/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/network/list/execute.ts
@@ -13,7 +13,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/network/remove/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/network/remove/execute.ts
@@ -16,7 +16,7 @@ export async function remove(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/network/update/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/network/update/execute.ts
@@ -17,7 +17,7 @@ export async function update(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/primary_ip/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/primary_ip/list/execute.ts
@@ -13,7 +13,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server/create/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server/create/execute.ts
@@ -88,7 +88,7 @@ export async function create(
 	console.log(options);
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server/get/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server/get/execute.ts
@@ -17,7 +17,7 @@ export async function get(this: IExecuteFunctions, index: number): Promise<INode
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server/list/execute.ts
@@ -15,7 +15,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server/metrics/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server/metrics/execute.ts
@@ -23,7 +23,7 @@ export async function metrics(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server/remove/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server/remove/execute.ts
@@ -19,7 +19,7 @@ export async function remove(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server/update/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server/update/execute.ts
@@ -30,7 +30,7 @@ export async function update(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/change_protection/description.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/change_protection/description.ts
@@ -1,0 +1,54 @@
+import type { ServerActionsProperties } from '../../Interfaces';
+
+export const changeProtectionDescription: ServerActionsProperties = [
+	{
+		displayName: 'Server',
+		name: 'id',
+		type: 'options',
+		placeholder: 'Select a server',
+		required: true,
+		typeOptions: {
+			loadOptionsMethod: 'getServers',
+		},
+		displayOptions: {
+			show: {
+				resource: ['server_actions'],
+				operation: ['change_protection'],
+			},
+		},
+		default: '',
+		description: 'ID of the Server.',
+	},
+	{
+		displayName: 'Delete Protection',
+		name: 'delete_protection',
+		type: 'boolean',
+		placeholder: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['server_actions'],
+				operation: ['change_protection'],
+			},
+		},
+		default: false,
+		description:
+			'If true, no deletion of the server is possible.',
+	},
+	{
+		displayName: 'Rebuild Protection',
+		name: 'rebuild_protection',
+		type: 'boolean',
+		placeholder: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['server_actions'],
+				operation: ['change_protection'],
+			},
+		},
+		default: false,
+		description:
+			'If true, no rebuild of the server is possible.',
+	},
+];

--- a/nodes/HetznerCloud/v1/actions/server_actions/change_protection/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/change_protection/execute.ts
@@ -1,18 +1,27 @@
 import type { IExecuteFunctions, IDataObject, INodeExecutionData } from 'n8n-workflow';
 import { OptionsWithUri } from 'request';
 
-export async function update(
+export async function changeProtection(
 	this: IExecuteFunctions,
 	index: number,
 ): Promise<INodeExecutionData[]> {
 	const id = this.getNodeParameter('id', index) as object;
+	const delete_protection = this.getNodeParameter('delete_protection', index) as boolean;
+	const rebuild_protection = this.getNodeParameter('rebuild_protection', index) as boolean;
 
 	const options: OptionsWithUri = {
-		method: 'UPDATE',
+		method: 'POST',
+		uri: `https://api.hetzner.cloud/v1/servers/` + id + '/actions/change_protection',
 		qs: {},
-		uri: `https://api.hetzner.cloud/v1/images/` + id,
+		body: {
+			delete: delete_protection,
+			rebuild: rebuild_protection,
+		},
 		json: true,
 	};
+
+	// console.log(options);
+
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
 		'hcloud',

--- a/nodes/HetznerCloud/v1/actions/server_actions/change_protection/index.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/change_protection/index.ts
@@ -1,0 +1,3 @@
+import { changeProtection as execute } from './execute';
+import { changeProtectionDescription as description } from './description';
+export { description, execute };

--- a/nodes/HetznerCloud/v1/actions/server_actions/change_server_type/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/change_server_type/execute.ts
@@ -24,7 +24,7 @@ export async function changeServerType(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/create_image/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/create_image/execute.ts
@@ -23,7 +23,7 @@ export async function create_image(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/description.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/description.ts
@@ -1,6 +1,6 @@
 import type { ServerActionsProperties } from '../../Interfaces';
 
-export const disable_backupDescription: ServerActionsProperties = [
+export const disableBackupDescription: ServerActionsProperties = [
 	{
 		displayName: 'server id',
 		name: 'id',

--- a/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/description.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/description.ts
@@ -1,0 +1,22 @@
+import type { ServerActionsProperties } from '../../Interfaces';
+
+export const disable_backupDescription: ServerActionsProperties = [
+	{
+		displayName: 'server id',
+		name: 'id',
+		type: 'options',
+		required: true,
+		placeholder: 'Select a server',
+		typeOptions: {
+			loadOptionsMethod: 'getServers',
+		},
+		displayOptions: {
+			show: {
+				resource: ['server_actions'],
+				operation: ['disable_backup'],
+			},
+		},
+		default: '',
+		description: 'ID of the Server.',
+	},
+];

--- a/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/execute.ts
@@ -1,7 +1,7 @@
 import type { IExecuteFunctions, IDataObject, INodeExecutionData } from 'n8n-workflow';
 import { OptionsWithUri } from 'request';
 
-export async function disable_backup(
+export async function disableBackup(
 	this: IExecuteFunctions,
 	index: number,
 ): Promise<INodeExecutionData[]> {
@@ -17,7 +17,7 @@ export async function disable_backup(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/execute.ts
@@ -1,0 +1,25 @@
+import type { IExecuteFunctions, IDataObject, INodeExecutionData } from 'n8n-workflow';
+import { OptionsWithUri } from 'request';
+
+export async function disable_backup(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const id = this.getNodeParameter('id', index) as object;
+
+	const options: OptionsWithUri = {
+		method: 'POST',
+		uri: `https://api.hetzner.cloud/v1/servers/` + id + '/actions/disable_backup',
+		json: true,
+	};
+
+	// console.log(options);
+
+	const responseData = await this.helpers.requestWithAuthentication.call(
+		this,
+		'hetznercloud',
+		options,
+	);
+
+	return this.helpers.returnJsonArray(responseData as IDataObject[]);
+}

--- a/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/index.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/index.ts
@@ -1,0 +1,4 @@
+import { disable_backup as execute } from './execute';
+import { disable_backupDescription as description } from './description';
+
+export { description, execute };

--- a/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/index.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/disable_backup/index.ts
@@ -1,4 +1,3 @@
-import { disable_backup as execute } from './execute';
-import { disable_backupDescription as description } from './description';
-
+import { disableBackup as execute } from './execute';
+import { disableBackupDescription as description } from './description';
 export { description, execute };

--- a/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/description.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/description.ts
@@ -1,0 +1,22 @@
+import type { ServerActionsProperties } from '../../Interfaces';
+
+export const enable_backupDescription: ServerActionsProperties = [
+	{
+		displayName: 'server id',
+		name: 'id',
+		type: 'options',
+		required: true,
+		placeholder: 'Select a server',
+		typeOptions: {
+			loadOptionsMethod: 'getServers',
+		},
+		displayOptions: {
+			show: {
+				resource: ['server_actions'],
+				operation: ['enable_backup'],
+			},
+		},
+		default: '',
+		description: 'ID of the Server.',
+	},
+];

--- a/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/description.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/description.ts
@@ -1,6 +1,6 @@
 import type { ServerActionsProperties } from '../../Interfaces';
 
-export const enable_backupDescription: ServerActionsProperties = [
+export const enableBackupDescription: ServerActionsProperties = [
 	{
 		displayName: 'server id',
 		name: 'id',

--- a/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/execute.ts
@@ -1,0 +1,25 @@
+import type { IExecuteFunctions, IDataObject, INodeExecutionData } from 'n8n-workflow';
+import { OptionsWithUri } from 'request';
+
+export async function enable_backup(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const id = this.getNodeParameter('id', index) as object;
+
+	const options: OptionsWithUri = {
+		method: 'POST',
+		uri: `https://api.hetzner.cloud/v1/servers/` + id + '/actions/enable_backup',
+		json: true,
+	};
+
+	// console.log(options);
+
+	const responseData = await this.helpers.requestWithAuthentication.call(
+		this,
+		'hetznercloud',
+		options,
+	);
+
+	return this.helpers.returnJsonArray(responseData as IDataObject[]);
+}

--- a/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/execute.ts
@@ -1,7 +1,7 @@
 import type { IExecuteFunctions, IDataObject, INodeExecutionData } from 'n8n-workflow';
 import { OptionsWithUri } from 'request';
 
-export async function enable_backup(
+export async function enableBackup(
 	this: IExecuteFunctions,
 	index: number,
 ): Promise<INodeExecutionData[]> {
@@ -17,7 +17,7 @@ export async function enable_backup(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/index.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/index.ts
@@ -1,4 +1,3 @@
-import { enable_backup as execute } from './execute';
-import { enable_backupDescription as description } from './description';
-
+import { enableBackup as execute } from './execute';
+import { enableBackupDescription as description } from './description';
 export { description, execute };

--- a/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/index.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/enable_backup/index.ts
@@ -1,0 +1,4 @@
+import { enable_backup as execute } from './execute';
+import { enable_backupDescription as description } from './description';
+
+export { description, execute };

--- a/nodes/HetznerCloud/v1/actions/server_actions/index.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/index.ts
@@ -6,8 +6,10 @@ import * as soft_reboot from './soft_reboot';
 import * as shutdown from './shutdown';
 import * as reset from './reset';
 import * as change_server_type from './change_server_type';
+import * as enable_backup from './enable_backup';
+import * as disable_backup from './disable_backup';
 
-export { create_image, power_off, power_on, soft_reboot, shutdown, reset, change_server_type };
+export { create_image, power_off, power_on, soft_reboot, shutdown, reset, change_server_type, enable_backup, disable_backup };
 
 export const descriptions: INodeProperties[] = [
 	{
@@ -69,6 +71,18 @@ export const descriptions: INodeProperties[] = [
 					'Changes the type (Cores, RAM and disk sizes) of a Server, Server must be powered off for this command to succeed.',
 				action: 'Change a Servers Server-type',
 			},
+			{
+				name: 'Enable Backup',
+				value: 'enable_backup',
+				description: 'Enables Hetzner backups for a server.',
+				action: 'Enable Backup For a Server',
+			},
+			{
+				name: 'Disable Backup',
+				value: 'disable_backup',
+				description: 'Disables Hetzner backups for a server.',
+				action: 'Disable Backup For a Server',
+			},
 		],
 		default: 'power_off',
 	},
@@ -79,4 +93,6 @@ export const descriptions: INodeProperties[] = [
 	...shutdown.description,
 	...reset.description,
 	...change_server_type.description,
+	...enable_backup.description,
+	...disable_backup.description,
 ];

--- a/nodes/HetznerCloud/v1/actions/server_actions/index.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/index.ts
@@ -8,8 +8,9 @@ import * as reset from './reset';
 import * as change_server_type from './change_server_type';
 import * as enable_backup from './enable_backup';
 import * as disable_backup from './disable_backup';
+import * as change_protection from './change_protection';
 
-export { create_image, power_off, power_on, soft_reboot, shutdown, reset, change_server_type, enable_backup, disable_backup };
+export { create_image, power_off, power_on, soft_reboot, shutdown, reset, change_server_type, enable_backup, disable_backup, change_protection };
 
 export const descriptions: INodeProperties[] = [
 	{
@@ -83,6 +84,13 @@ export const descriptions: INodeProperties[] = [
 				description: 'Disables Hetzner backups for a server.',
 				action: 'Disable Backup For a Server',
 			},
+			{
+				name: 'Change Protection',
+				value: 'change_protection',
+				description:
+					'Changes the protection of a Server against accidental deletion or rebuild.',
+				action: 'Change a Servers Protection',
+			},
 		],
 		default: 'power_off',
 	},
@@ -95,4 +103,5 @@ export const descriptions: INodeProperties[] = [
 	...change_server_type.description,
 	...enable_backup.description,
 	...disable_backup.description,
+	...change_protection.description
 ];

--- a/nodes/HetznerCloud/v1/actions/server_actions/power_off/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/power_off/execute.ts
@@ -17,7 +17,7 @@ export async function power_off(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/power_on/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/power_on/execute.ts
@@ -17,7 +17,7 @@ export async function power_on(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/reset/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/reset/execute.ts
@@ -14,7 +14,7 @@ export async function reset(this: IExecuteFunctions, index: number): Promise<INo
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/shutdown/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/shutdown/execute.ts
@@ -17,7 +17,7 @@ export async function shutdown(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/server_actions/soft_reboot/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/server_actions/soft_reboot/execute.ts
@@ -17,7 +17,7 @@ export async function soft_reboot(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/ssh/create/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/ssh/create/execute.ts
@@ -15,7 +15,7 @@ export async function create(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/ssh/get/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/ssh/get/execute.ts
@@ -13,7 +13,7 @@ export async function get(this: IExecuteFunctions, index: number): Promise<INode
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/ssh/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/ssh/list/execute.ts
@@ -13,7 +13,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/ssh/remove/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/ssh/remove/execute.ts
@@ -15,7 +15,7 @@ export async function remove(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/ssh/update/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/ssh/update/execute.ts
@@ -19,7 +19,7 @@ export async function update(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/versionDescription.ts
+++ b/nodes/HetznerCloud/v1/actions/versionDescription.ts
@@ -13,8 +13,8 @@ import * as volume from './volume';
 import * as server_actions from './server_actions';
 
 export const versionDescription: INodeTypeDescription = {
-	displayName: 'HetznerCloud',
-	name: 'hetznercloud',
+	displayName: 'Hetzner hcloud',
+	name: 'hcloud',
 	icon: 'file:hetznercloud.svg',
 	group: ['output'],
 	version: 1,
@@ -27,7 +27,7 @@ export const versionDescription: INodeTypeDescription = {
 	outputs: ['main'],
 	credentials: [
 		{
-			name: 'hetznercloud',
+			name: 'hcloud',
 			required: true,
 		},
 	],

--- a/nodes/HetznerCloud/v1/actions/volume/create/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/volume/create/execute.ts
@@ -31,7 +31,7 @@ export async function create(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 	return this.helpers.returnJsonArray(responseData as IDataObject[]);

--- a/nodes/HetznerCloud/v1/actions/volume/get/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/volume/get/execute.ts
@@ -12,7 +12,7 @@ export async function get(this: IExecuteFunctions, index: number): Promise<INode
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/volume/list/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/volume/list/execute.ts
@@ -13,7 +13,7 @@ export async function list(this: IExecuteFunctions, index: number): Promise<INod
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/actions/volume/remove/execute.ts
+++ b/nodes/HetznerCloud/v1/actions/volume/remove/execute.ts
@@ -15,7 +15,7 @@ export async function remove(
 
 	const responseData = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 

--- a/nodes/HetznerCloud/v1/methods/loadOptions.ts
+++ b/nodes/HetznerCloud/v1/methods/loadOptions.ts
@@ -13,7 +13,7 @@ export async function getServers(this: ILoadOptionsFunctions): Promise<INodeProp
 		uri: `https://api.hetzner.cloud/v1/servers`,
 		json: true,
 	};
-	let results = await helpPaginate(this, 'hetznercloud', options, new Array<any>(), 'servers');
+	let results = await helpPaginate(this, 'hcloud', options, new Array<any>(), 'servers');
 	if (results) {
 		for (const server of results) {
 			returnData.push({
@@ -34,7 +34,7 @@ export async function getFirewalls(this: ILoadOptionsFunctions): Promise<INodePr
 		json: true,
 		timeout: 2000,
 	};
-	let results = await helpPaginate(this, 'hetznercloud', options, new Array<any>(), 'firewalls');
+	let results = await helpPaginate(this, 'hcloud', options, new Array<any>(), 'firewalls');
 	if (results) {
 		for (const firewall of results) {
 			returnData.push({
@@ -58,7 +58,7 @@ export async function getServertypes(this: ILoadOptionsFunctions): Promise<INode
 
 	const servertypelist = await this.helpers.requestWithAuthentication.call(
 		this,
-		'hetznercloud',
+		'hcloud',
 		options,
 	);
 
@@ -81,7 +81,7 @@ export async function getImages(this: ILoadOptionsFunctions): Promise<INodePrope
 		uri: `https://api.hetzner.cloud/v1/images`,
 		json: true,
 	};
-	let results = await helpPaginate(this, 'hetznercloud', options, new Array<any>(), 'images');
+	let results = await helpPaginate(this, 'hcloud', options, new Array<any>(), 'images');
 	console.log('Pagination size: ', results.length);
 	if (results) {
 		for (const image of results) {
@@ -102,7 +102,7 @@ export async function getLocations(this: ILoadOptionsFunctions): Promise<INodePr
 		uri: `https://api.hetzner.cloud/v1/datacenters`,
 		json: true,
 	};
-	let results = await helpPaginate(this, 'hetznercloud', options, new Array<any>(), 'datacenters');
+	let results = await helpPaginate(this, 'hcloud', options, new Array<any>(), 'datacenters');
 	//	console.log('Pagination size: ', results.length);
 	if (results) {
 		for (const datacenter of results) {
@@ -123,7 +123,7 @@ export async function getVolumes(this: ILoadOptionsFunctions): Promise<INodeProp
 		uri: `https://api.hetzner.cloud/v1/volumes`,
 		json: true,
 	};
-	let results = await helpPaginate(this, 'hetznercloud', options, new Array<any>(), 'volumes');
+	let results = await helpPaginate(this, 'hcloud', options, new Array<any>(), 'volumes');
 	//	console.log('Pagination size: ', results.length);
 	if (results) {
 		for (const volume of results) {
@@ -145,7 +145,7 @@ export async function getDatacenters(this: ILoadOptionsFunctions): Promise<INode
 		uri: `https://api.hetzner.cloud/v1/datacenters`,
 		json: true,
 	};
-	let results = await helpPaginate(this, 'hetznercloud', options, new Array<any>(), 'datacenters');
+	let results = await helpPaginate(this, 'hcloud', options, new Array<any>(), 'datacenters');
 	//	console.log('Pagination size: ', results.length);
 	if (results) {
 		for (const datacenter of results) {
@@ -166,7 +166,7 @@ export async function getSshkeys(this: ILoadOptionsFunctions): Promise<INodeProp
 		uri: `https://api.hetzner.cloud/v1/ssh_keys`,
 		json: true,
 	};
-	let results = await helpPaginate(this, 'hetznercloud', options, new Array<any>(), 'ssh_keys');
+	let results = await helpPaginate(this, 'hcloud', options, new Array<any>(), 'ssh_keys');
 	//	console.log('Pagination size: ', results.length);
 	if (results) {
 		for (const key of results) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "n8n-nodes-hetznercloud",
-	"version": "0.2.0",
+	"name": "n8n-nodes-hcloud",
+	"version": "0.2.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "n8n-nodes-hetznercloud",
-			"version": "0.2.0",
+			"name": "n8n-nodes-hcloud",
+			"version": "0.2.6",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/express": "^4.17.6",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,17 @@
 {
-	"name": "n8n-nodes-hetznercloud",
-	"version": "0.2.0",
-	"description": "n8n app to interact with the Cloud API from Hetzner.",
+	"name": "n8n-nodes-hcloud",
+	"version": "0.2.6",
+	"description": "n8n app to interact with the Cloud API from Hetzner. Slightly enhanced.",
 	"keywords": [
 		"n8n-community-node-package"
 	],
 	"license": "MIT",
-	"homepage": "https://seatable.io/integrations/",
 	"author": {
-		"name": "Christoph Dyllick-Brenzinger",
-		"email": "cdb@seatable.io"
+		"name": "Oxery"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/christophdb/n8n-hetzner-cloud.git"
+		"url": "https://github.com/OXERY/n8n-nodes-hcloud.git"
 	},
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Hi,

Thanks for your great project! I hope you are open to PRs :-)
As I also wanted to enable/disable backups for my Hetzner servers via n8n, I quickly stepped into the Hetzner API docs - and as it seems to be just as simple as turning the machine on and off, I didn't create an issue, but directly a PR.

API Docs regarding this topic: https://docs.hetzner.cloud/#server-actions-enable-and-configure-backups-for-a-server

If it needs any changes, just let me know.

Best

Dennis